### PR TITLE
Initial Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Nutty
+#### A simple HTTP paste server
+
+Nutty is a self-hostable paste server, allowing you to easily upload and share text files instantly.
+
+## Features
+- A simple HTTP interface
+- Public and private pastes
+- Low memory footprint
+
+## Installation
+
+1. Make sure you have Deno installed on your system. If not, you can install it by following the instructions on the [Deno website](https://deno.land/#installation).
+2. Clone the repository by running `git clone https://github.com/JLCarveth/nutty.git`.
+3. Change into the cloned directory by running `cd nutty`.
+4. Run the `paste.ts` file with Deno by running `deno run -A --unstable paste.ts`.
+
+A simple systemd service can also be setup to handle stopping/starting Nutty:
+```Systemd
+[Unit]
+Description=File pasting API
+
+[Service]
+ExecStart=/home/jlcarveth/.deno/bin/deno run -A --unstable paste.ts
+Restart=always
+User=jlcarveth
+Group=jlcarveth
+WorkingDirectory=/opt/paste
+EnvironmentFile=/opt/paste/.env
+StandardOutput=/var/log/paste/out.log
+StandardError=/var/log/paste/error.log
+
+[Install]
+WantedBy=multi-user.target
+```
+### Environment
+Nutty depends on a couple of environment variables to be established before running.
+|Variable Name|Description|Example Values|
+|---|---|---|
+|`TARGET_DIR`|The directory where pastes will be stored.|`/opt/paste/data`|
+|`BASE_URL`|The base URL at which the API can be accessed.|`https://paste.mysite.com/api`|
+|`SECRET_KEY`|Used for signing JWTs. A secret key can be generated with `openssl rand -base64 32`|`GDZ1FzBF18dtAk2enanqqxskVf5hptmPjy/pcBm384M=`|
+|`PORT`|The port to listen to. Default is 5335|`5335`|
+
+## Usage
+

--- a/client.sh
+++ b/client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Read environment variables
-UUID=${UUID}
+EMAIL=${EMAIL}
 TOKEN=${TOKEN}
 API_URL=${API_URL}
 RECIPIENT=${RECIPIENT}
@@ -10,7 +10,8 @@ RECIPIENT=${RECIPIENT}
 TEXT=$(cat)
 
 # Encrypt text with gpg
-ENCRYPTED_TEXT=$(echo "${TEXT}" | gpg --encrypt --armor --recipient "${RECIPIENT}")
+ENCRYPTED_TEXT=$(echo "${TEXT}" | gpg --encrypt --armor --recipient "${EMAIL}")
 
 # Send POST request with curl
-curl -X POST -H "X-Access-Token: ${TOKEN}" -d "${ENCRYPTED_TEXT}" "${API_URL}/paste"
+UUID=$(curl -X POST -H "X-Access-Token: ${TOKEN}" -d "${ENCRYPTED_TEXT}" "${API_URL}/paste")
+echo $UUID

--- a/paste.ts
+++ b/paste.ts
@@ -2,7 +2,7 @@
  * A Pastebin-like backend using Zippy
  *
  * @author John L. Carveth <jlcarveth@gmail.com>
- * @version 0.4.0
+ * @version 1.0.0
  * @namespace nutty
  *
  * Provides basic authentication via /api/login and /api/register routes.
@@ -18,7 +18,7 @@ const SQLiteService = service.getInstance();
 export const PORT = Number.parseInt(<string> Deno.env.get("PORT") ?? 5335);
 const TARGET_DIR = Deno.env.get("TARGET_DIR") || "/opt/paste/";
 const BASE_URL = Deno.env.get("BASE_URL");
-export const version = "0.5.0";
+export const version = "1.0.0";
 
 /**
  * Authenticate with the API to recieve an access token
@@ -31,16 +31,16 @@ export const version = "0.5.0";
  */
 post("/api/login", async (req, _path, _params) => {
   const body = await req.json();
-  const uuid = body.userid;
+  const email = body.email;
   const password = body.password;
 
-  if (!uuid || !password) {
+  if (!email || !password) {
     return new Response("Invalid request. Missing parameters.", {
       status: 400,
     });
   }
   try {
-    const token = await SQLiteService.login(uuid, password);
+    const token = await SQLiteService.login(email, password);
     return new Response(token);
   } catch (err) {
     return new Response(err.message, { status: 401 });
@@ -57,10 +57,13 @@ post("/api/login", async (req, _path, _params) => {
  */
 post("/api/register", async (req, _path, _params) => {
   const body = await req.json();
+  const email = body.email;
   const password = body.password;
 
-  if (!password) return new Response("Missing parameters", { status: 400 });
-  const uuid = SQLiteService.register(password);
+  if (!email || !password) {
+    return new Response("Missing parameters", { status: 400 });
+  }
+  const uuid = SQLiteService.register(email, password);
   return new Response(uuid);
 });
 

--- a/test.ts
+++ b/test.ts
@@ -6,7 +6,7 @@ import "./paste.ts";
 import { PORT, version } from "./paste.ts";
 
 const baseURL = `http://localhost:${PORT}`;
-const testUser = { uuid: "", password: "password" };
+const testUser = { uuid: "", password: "password", email: "test@gmail.com" };
 
 function isValidUUID(uuid: string) {
   const regex = new RegExp(
@@ -46,6 +46,7 @@ async function testRegister() {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
+      "email": testUser.email,
       "password": testUser.password,
     }),
   });
@@ -84,7 +85,7 @@ async function testLogin() {
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ userid: testUser.uuid, password: "WRONGPASSWORD" }),
+    body: JSON.stringify({ email: testUser.email, password: "WRONGPASSWORD" }),
   });
 
   console.assert(


### PR DESCRIPTION
Switched from using UUIDs for login / registration to using email addresses. UUIDs are still stored with the account details and are used as the path to store private pastes.