### PR TITLE
Dev

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -70,7 +70,6 @@ footer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem;
   background-color: #00F;
   color: white;
   position: absolute;
@@ -87,4 +86,16 @@ ul.footer-links {
 ul.footer-links a {
   text-decoration: none;
   color: white;
+}
+
+div.login-form {
+  margin: auto;
+}
+
+input.form-control {
+  border-radius: 4px;
+  border: 1px solid black;
+  padding: 10px 20px;
+  margin: 10px;
+  width: 100%;
 }

--- a/templates/login.ts
+++ b/templates/login.ts
@@ -1,3 +1,15 @@
+const BASE_URL = Deno.env.get("BASE_URL");
 export function Login() {
-  return `<h1>Login Coming Soon</h1>`;
+  return (`
+    <div class="login-form">
+    <form method="POST" action="http://localhost:5335/api/login">
+      <label for="email" class="form-label">Email</label>
+      <input type="email" name="email" placeholder="janedoe@mail.com" class="form-control"/>
+      <label for="password" class="form-label">Password</label>
+      <input type="password" name="password" class="form-control" placeholder="password"/>
+      <input type="submit" value="Login"/>
+      <input type="reset" value="Reset"/>
+    </form>
+    </div>
+  `);
 }


### PR DESCRIPTION
Modified `POST-/api/login`:
- If the incoming requests has an `Accept` header for `text/html`, then the client is redirected to the site root on successful login.
- If the incoming request has a `Content-Type` of `x-www-form-urlencoded`, then parameters are parsed appropriately.